### PR TITLE
Fix back button behaviour

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,6 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:noHistory="true"
             android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -39,7 +38,6 @@
         </activity>
         <activity
             android:name=".SettingsActivity"
-            android:noHistory="true"
             android:screenOrientation="portrait" />
     </application>
 

--- a/app/src/main/java/theredspy15/ltecleanerfoss/SettingsActivity.java
+++ b/app/src/main/java/theredspy15/ltecleanerfoss/SettingsActivity.java
@@ -93,9 +93,7 @@ public class SettingsActivity extends AppCompatActivity {
      * @param view the view that is clicked
      */
     public final void back(View view) {
-
-        Intent randomIntent = new Intent(this, MainActivity.class);
-        startActivity(randomIntent);
+        super.onBackPressed();
     }
 
     /**

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -248,8 +248,7 @@
         fancy:fb_focusColor="@color/colorAccent"
         fancy:fb_radius="30dp"
         fancy:fb_text="@string/make_suggestion"
-        fancy:fb_textColor="@color/buttonText"
-        app:fb_text="@string/make_suggestion" />
+        fancy:fb_textColor="@color/buttonText" />
 
     <TextView
         android:id="@+id/textView3"


### PR DESCRIPTION
Removed a duplicate attribute in the settings layout that prevented building the app.

Otherwise corrected the behaviour of the app in regards to the back button.

For example, pressing the back button in the settings closed the app instead of going back to the main activity. This also fixes going from the issue reporter back to settings.